### PR TITLE
Added online emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 asm
 ==============
 
-Learning assembly for linux-x64
+Learning assembly for linux-x64.<br/>
+You can use [emu86](http://www.emu86.org/main) to try asm online.
 
 Examples
 ==============

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ asm
 ==============
 
 Learning assembly for linux-x64.<br/>
-You can use [emu86](http://www.emu86.org/main) to try asm online.
+You can use [emu86](http://www.emu86.org) to try asm online.
 
 Examples
 ==============


### PR DESCRIPTION
This commit adds online asm emulator.
It includes a subset of x86 assembler instructions to learn.
More details about how this works can be found here: http://www.emu86.org/help