### PR TITLE
Remove links for the issue template

### DIFF
--- a/.github/issue-template.md
+++ b/.github/issue-template.md
@@ -1,7 +1,7 @@
 <!-- Thank you for your contribution. Before you submit the issue:
 - Search open and closed issues for duplicates.
-- Read the [Contributing guidelines](../contributing.md).
-- Follow the [Code of Conduct](../CODE_OF_CONDUCT.md).
+- Read the Contributing guidelines.
+- Follow the Code of Conduct.
 -->
 
 **Description**

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,6 +1,6 @@
 <!-- Thank you for your contribution. When contributing to the project, remember to:
-- Read the [Contribution guide](../contributing.md).
-- Follow the [Code of Conduct](../CODE_OF_CONDUCT.md).
+- Read the Contribution guide.
+- Follow the Code of Conduct.
 -->
 
 **Description**


### PR DESCRIPTION
<!-- Thank you for your contribution. When contributing to the project, remember to:
- Read the [Contribution guide](../contributing.md).
- Follow the [Code of Conduct](../CODE_OF_CONDUCT.md).
-->

**Description**

The issue and pull request templates contained the links to contribution guide and code of conduct. However, these links are not usable. This PR removes them. 

Changes proposed in this pull request:

- Remove links for the issue and pull request template

**Related issues**

https://github.com/0xAX/asm/issues/22