### PR TITLE
Improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -38,20 +38,6 @@ body:
     validations:
       required: true
 
-  - type: input
-    attributes:
-      label: Environment?????
-      description: ????
-    validations:
-      required: false
-
-  - type: input
-    attributes:
-      label: Version??????
-      description: ????
-    validations:
-      required: false
-
   - type: textarea
     attributes:
       label: Suggested improvements

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,67 @@
+name: 🐛 Bug in a code example
+description: Report a bug in a code example
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to report a bug in a code example.
+
+        When contributing, make sure to follow Contributing guidelines and Code of Conduct.
+        Thank you for your contribution!
+
+  - type: checkboxes
+    attributes:
+      label: Existing issues
+      description: Is there an existing issue for this? Search open and closed issues to avoid duplicates.
+      options:
+        - label: I have searched the existing issues.
+          required: true
+
+  - type: input
+    attributes:
+      label: Affected code example
+      description: Name or paste a link to the affected code example
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Issue description
+      description: Explain what is wrong with the code example.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual vs expected result
+      description: Describe the result you got and how it's different from what you expected to see.
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Environment?????
+      description: ????
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Version??????
+      description: ????
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Suggested improvements
+      description: Share your ideas or suggestions on how this code example could be improved. Be as specific as possible.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Attachments
+      description: Include screenshots, links, or example's output if applicable.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/content-issue.yml
+++ b/.github/ISSUE_TEMPLATE/content-issue.yml
@@ -1,10 +1,10 @@
-name: 📖 Documentation issue
-description: Report an issue with documentation
+name: 📖 Content issue
+description: Report an issue with the content
 body:
   - type: markdown
     attributes:
       value: |
-        Use this form to report an issue with documentation.
+        Use this form to report an issue with the content.
 
         When contributing, make sure to follow Contributing guidelines and Code of Conduct.
         Thank you for your contribution!

--- a/.github/ISSUE_TEMPLATE/documentation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.yml
@@ -1,0 +1,39 @@
+name: 📖 Documentation issue
+description: Report an issue with documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to report an issue with documentation.
+
+        When contributing, make sure to follow Contributing guidelines and Code of Conduct.
+        Thank you for your contribution!
+
+  - type: checkboxes
+    attributes:
+      label: Existing issues
+      description: Is there an existing issue for this? Search open and closed issues to avoid duplicates.
+      options:
+        - label: I have searched the existing issues.
+          required: true
+
+  - type: input
+    attributes:
+      label: Affected document
+      description: Name or paste a link to the document that contains an issue.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Issue description
+      description: Explain what is unclear or confusing in the given document.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Attachments
+      description: Include screenshots or links if applicable.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,39 @@
+name: ❓ Questions and discussions
+description: Ask a question or start a discussion with other community members.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to ask a question or start a discussion with other community members.
+
+        When contributing, make sure to follow Contributing guidelines and Code of Conduct.
+        Thank you for your contribution!
+
+  - type: checkboxes
+    attributes:
+      label: Existing issues
+      description: Is there an existing issue for this? Search open and closed issues to avoid duplicates.
+      options:
+        - label: I have searched the existing issues.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Question
+      description: Ask a question you would like to discuss with the community.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Discussion
+      description: Start a discussion topic.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Attachments
+      description: Include screenshots, links, or example's output if applicable.
+    validations:
+      required: false

--- a/.github/issue-template.md
+++ b/.github/issue-template.md
@@ -1,9 +1,0 @@
-<!-- Thank you for your contribution. Before you submit the issue:
-- Search open and closed issues for duplicates.
-- Read the Contributing guidelines.
-- Follow the Code of Conduct.
--->
-
-**Description**
-
-<!-- In this section, provide a clear and concise description of the issue. Provide proper argumentation and screenshots, if necessary. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This document outlines the contribution workflow, starting from opening an issue
 
 Thank you for your contribution.
 
-## New contributor guide 
+## New contributor guide
 
 If you are a new open source contributor, here are some resources you may find useful before providing your first contributions:
 
@@ -15,7 +15,7 @@ If you are a new open source contributor, here are some resources you may find u
 
 **Working on your first pull request?** You can learn how from this free series [How to Contribute to an Open Source Project on GitHub](https://kcd.im/pull-request).
 
-## Create an issue 
+## Create an issue
 
 If you have any improvement ideas, notice a missing feature or a bug, create a GitHub issue by clicking **Issues -> New issue** in GitHub. Make sure to fill the issue template with a detailed description of the bug or suggested improvements. Provide proper argumentation and screenshots, if necessary.
 
@@ -29,17 +29,17 @@ If you want to directly contribute to the project, create a pull reguest with th
 
 2. Make changes on your local copy of the forked repository.
 
-3. Commit and push the changes to GitHub. 
+3. Commit and push the changes to GitHub.
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > Don't forget to update your fork. Since many contributors may be working on the same content based on the `master` branch, some merge conflicts may occur. Remember to rebase with `master` every time before pushing your changes and make sure your branch doesn't have any conflicts with `master`. If you run into any merge conflicts, read the [Resolve merge conflicts](https://github.com/skills/resolve-merge-conflicts) tutorial to learn how to resolve merge conflicts and other issues.
 
 4. Open a pull request in GitHub. Fill the pull request template with the reason and description for the provided changes. Link your pull request with the existing issue, if applicable. After submitting your PR, wait for the review from the project maintainers.
 
 ## Review and approval process
 
-After you submit your PR, wait for the review. The project maintainers will evaluate your changes and provide feedback either using [suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request) or pull request comments. Address the review suggestions and comments as soon as you can. If your PR looks good, the maintainers approve and merge it. 
+After you submit your PR, wait for the review. The project maintainers will evaluate your changes and provide feedback either using [suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request) or pull request comments. Address the review suggestions and comments as soon as you can. If your PR looks good, the maintainers approve and merge it.
 
-## Contributors 
+## Contributors
 
 All contributions get credit in [Contributors](CONTRIBUTORS.md). Don't forget to add yourself there. 


### PR DESCRIPTION
<!-- Thank you for your contribution. When contributing to the project, remember to:
- Read the Contribution guide.
- Follow the Code of Conduct.
-->

**Description**

Seems there are new rules on [how to add issue templates to the repo](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser). This PR adds three issue templates for:

- Bugs in code examples
- Content issues
- Questions and discussions
