### PR TITLE
Unify indentation in examples

### DIFF
--- a/casm/casm1/casm.asm
+++ b/casm/casm1/casm.asm
@@ -1,28 +1,28 @@
 ;; Definition of the `data` section
 section .data
-    ;; String variable with the value `hello world!`
-    msg db "hello, world!"
+        ;; String variable with the value `hello world!`
+        msg db "hello, world!"
 
-    ;; Reference to the C stdlib functions that we will use
-    extern write, exit
+        ;; Reference to the C stdlib functions that we will use
+        extern write, exit
 
 ;; Definition of the text section
 section .text
-    ;; Reference to the entry point of our program
-    global _start
+        ;; Reference to the entry point of our program
+        global _start
 
 ;; Entry point
 _start:
-    ;; Set the first argument of the `write` function to 1 (`stdout`).
-    mov rdi, 1
-    ;; Set the second argument of the `write` function to the reference of the `msg` variable.
-    mov rsi, msg
-    ;; Set the third argument to the length of the `msg` variable's value (13 bytes).
-    mov rdx, 13
-    ;; Call the `write` function.
-    call write
+        ;; Set the first argument of the `write` function to 1 (`stdout`).
+        mov rdi, 1
+        ;; Set the second argument of the `write` function to the reference of the `msg` variable.
+        mov rsi, msg
+        ;; Set the third argument to the length of the `msg` variable's value (13 bytes).
+        mov rdx, 13
+        ;; Call the `write` function.
+        call write
 
-    ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
-    mov rdi, 0
-    ;; Call the `exit` function
-    call exit
+        ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
+        mov rdi, 0
+        ;; Call the `exit` function
+        call exit

--- a/content/asm_1.md
+++ b/content/asm_1.md
@@ -142,33 +142,33 @@ Let's write our first assembly program based on this code sample:
 ```assembly
 ;; Definition of the `data` section
 section .data
-    ;; String variable with the value `hello world!`
-    msg db      "hello, world!"
+        ;; String variable with the value `hello world!`
+        msg db "hello, world!"
 
 ;; Definition of the text section
 section .text
-    ;; Reference to the entry point of our program
-    global _start
+        ;; Reference to the entry point of our program
+        global _start
 
 ;; Entry point
 _start:
-    ;; Specify the number of the system call (1 is `sys_write`).
-    mov     rax, 1
-    ;; Set the first argument of `sys_write` to 1 (`stdout`).
-    mov     rdi, 1
-    ;; Set the second argument of `sys_write` to the reference of the `msg` variable.
-    mov     rsi, msg
-    ;; Set the third argument of `sys_write` to the length of the `msg` variable's value (13 bytes).
-    mov     rdx, 13
-    ;; Call the `sys_write` system call.
-    syscall
+        ;; Specify the number of the system call (1 is `sys_write`).
+        mov rax, 1
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, 1
+        ;; Set the second argument of `sys_write` to the reference of the `msg` variable.
+        mov rsi, msg
+        ;; Set the third argument of `sys_write` to the length of the `msg` variable's value (13 bytes).
+        mov rdx, 13
+        ;; Call the `sys_write` system call.
+        syscall
 
-    ;; Specify the number of the system call (60 is `sys_exit`).
-    mov    rax, 60
-    ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
-    mov    rdi, 0
-    ;; Call the `sys_exit` system call.
-    syscall
+        ;; Specify the number of the system call (60 is `sys_exit`).
+        mov rax, 60
+        ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
+        mov rdi, 0
+        ;; Call the `sys_exit` system call.
+        syscall
 ```
 
 This may look quite long compared to the "Hello, World!" program written using a high-level programming language. Let’s break it down and understand how it works.

--- a/content/asm_2.md
+++ b/content/asm_2.md
@@ -166,12 +166,12 @@ For example:
 
 ```assembly
 section .data
-    ;; Define a byte with the value 100
-    num1   db 100
-    ;; Define 2 bytes with the value 1024
-    num2   dw 1024
-    ;; Define a set of characters (10 is a new line symbol in ASCII \n)
-    msg    db "Sum is correct", 10
+        ;; Define a byte with the value 100
+        num1 db 100
+        ;; Define 2 bytes with the value 1024
+        num2 dw 1024
+        ;; Define a set of characters (10 is a new line symbol in ASCII \n)
+        msg db "Sum is correct", 10
 ```
 
 There are also alternatives to define uninitialized storage - `RESB`, `RESW`, `RESD`, `RESQ`, `REST`, `RESO`, `RESY`, and `RESZ`. These are used similarly to `DB` - `DZ`, but in this case, we do not provide an initial value for the defined variable.
@@ -180,8 +180,8 @@ For example:
 
 ```assembly
 section .bss
-    ;; Define a buffer with the size 64 bytes
-    buffer resb 64
+        ;; Define a buffer with the size 64 bytes
+        buffer resb 64
 ```
 
 After defining variables, we can start using them in our program's code. To use a variable, we can refer it by name. However, there is a small thing to remember in the NASM assembly syntax: accessing a variable by name gets us its address, not the actual value it stores:
@@ -241,55 +241,55 @@ If we compile it and look at the assembly code, we will see such an output of th
 ```assembly
 bar:
         ;; Preserve the base pointer
-        push    rbp
+        push rbp
         ;; Set the new frame base pointer
-        mov     rbp, rsp
+        mov rbp, rsp
         ;; Push the eight argument on the stack
-        push    8
+        push 8
         ;; Push the seventh argument on the stack
-        push    7
+        push 7
         ;; Push the sixth argument on the stack
-        mov     r9d, 6
+        mov r9d, 6
         ;; Push the fifth argument on the stack
-        mov     r8d, 5
+        mov r8d, 5
         ;; Push the fourth argument on the stack
-        mov     ecx, 4
+        mov ecx, 4
         ;; Push the third argument on the stack
-        mov     edx, 3
+        mov edx, 3
         ;; Push the second argument on the stack
-        mov     esi, 2
+        mov esi, 2
         ;; Push the first argument on the stack
-        mov     edi, 1
+        mov edi, 1
         ;; Call the function `foo`
-        call    foo
+        call foo
         ;; Clean up the stack from the 8th and 7th arguments
-        add     rsp, 16
+        add rsp, 16
         ;; Restore the old rbp
         leave
         ;; Return from the function
         ret
 foo:
         ;; Preserve the base pointer
-        push    rbp
+        push rbp
         ;; Set the new frame base pointer
-        mov     rbp, rsp
+        mov rbp, rsp
         ;; Move 4 bytes value from the edi register to the address stored in the rbp register minus 4 bytes offset
-        mov     DWORD PTR [rbp-4], edi
+        mov DWORD PTR [rbp-4], edi
         ;; Move 4 bytes value from the esi register to the address stored in the rbp register minus 8 bytes offset
-        mov     DWORD PTR [rbp-8], esi
+        mov DWORD PTR [rbp-8], esi
         ;; Move 4 bytes value from the edx register to the address stored in the rbp register minus 12 bytes offset
-        mov     DWORD PTR [rbp-12], edx
+        mov DWORD PTR [rbp-12], edx
         ;; Move 4 bytes value from the ecx register to the address stored in the rbp register minus 16 bytes offset
-        mov     DWORD PTR [rbp-16], ecx
+        mov DWORD PTR [rbp-16], ecx
         ;; Move 4 bytes value from the r8d register to the address stored in the rbp register minus 20 bytes offset
-        mov     DWORD PTR [rbp-20], r8d
+        mov DWORD PTR [rbp-20], r8d
         ;; Move 4 bytes value from the r9d register to the address stored in the rbp register minus 24 bytes offset
-        mov     DWORD PTR [rbp-24], r9d
+        mov DWORD PTR [rbp-24], r9d
         ...
         ... # Skip arithmetic operations for now
         ...
         ;; Restore the old rbp
-        pop     rbp
+        pop rbp
         ;; Return from the function
         ret
 ```
@@ -300,8 +300,8 @@ foo:
 First of all, let's take a look at the first two lines of code in the function `bar`:
 
 ```assembly
-push    rbp
-mov     rbp, rsp
+push rbp
+mov rbp, rsp
 ```
 
 These two instructions at the beginning of each function are called [function prologue](https://en.wikipedia.org/wiki/Function_prologue_and_epilogue#Prologue). Each function usually operates with a part of the stack. Such a part is called a [stack frame](https://en.wikipedia.org/wiki/Call_stack). To manage the stack, the CPU uses these general purpose registers:
@@ -418,57 +418,57 @@ Here is the source code of our example:
 ```assembly
 ;; Definition of the .data section
 section .data
-    ;; The first number
-    num1 dq 0x64
-    ;; The second number
-    num2 dq 0x32
-    ;; The message to print if the sum is correct
-    msg  db "The sum is correct!", 10
+        ;; The first number
+        num1 dq 0x64
+        ;; The second number
+        num2 dq 0x32
+        ;; The message to print if the sum is correct
+        msg db "The sum is correct!", 10
 
 ;; Definition of the .text section
 section .text
-    ;; Reference to the entry point of our program
-    global _start
+        ;; Reference to the entry point of our program
+        global _start
 
 ;; Entry point
 _start:
-    ;; Set the value of num1 to rax
-    mov rax, [num1]
-    ;; Set the value of num2 to rbx
-    mov rbx, [num2]
-    ;; Get the sum of rax and rbx. The result is stored in rax.
-    add rax, rbx
+        ;; Set the value of num1 to rax
+        mov rax, [num1]
+        ;; Set the value of num2 to rbx
+        mov rbx, [num2]
+        ;; Get the sum of rax and rbx. The result is stored in rax.
+        add rax, rbx
 .compare:
-    ;; Compare the rax value with 150
-    cmp rax, 150
-    ;; Go to the .exit label if the rax value is not 150
-    jne .exit
-    ;; Go to the .correctSum label if the rax value is 150
-    jmp .correctSum
+        ;; Compare the rax value with 150
+        cmp rax, 150
+        ;; Go to the .exit label if the rax value is not 150
+        jne .exit
+        ;; Go to the .correctSum label if the rax value is 150
+        jmp .correctSum
 
 ;; Print a message that the sum is correct
 .correctSum:
-    ;; Specify the system call number (1 is `sys_write`).
-    mov rax, 1
-    ;; Set the first argument of `sys_write` to 1 (`stdout`).
-    mov rdi, 1
-    ;; Set the second argument of `sys_write` to the reference of the `msg` variable.        
-    mov rsi, msg
-    ;; Set the third argument to the length of the `msg` variable's value (20 bytes).
-    mov rdx, 20
-    ;; Call the `sys_write` system call.
-    syscall
-    ;; Go to the exit of the program.
-    jmp .exit
+        ;; Specify the system call number (1 is `sys_write`).
+        mov rax, 1
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, 1
+        ;; Set the second argument of `sys_write` to the reference of the `msg` variable.
+        mov rsi, msg
+        ;; Set the third argument to the length of the `msg` variable's value (20 bytes).
+        mov rdx, 20
+        ;; Call the `sys_write` system call.
+        syscall
+        ;; Go to the exit of the program.
+        jmp .exit
 
 ;; Exit procedure
 .exit:
-    ;; Specify the number of the system call (60 is `sys_exit`).
-    mov rax, 60
-    ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
-    mov rdi, 0
-    ;; Call the `sys_exit` system call.
-    syscall
+        ;; Specify the number of the system call (60 is `sys_exit`).
+        mov rax, 60
+        ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
+        mov rdi, 0
+        ;; Call the `sys_exit` system call.
+        syscall
 ```
 
 First, let's build our program using the commands we learned in the previous chapter to see the result:

--- a/content/asm_3.md
+++ b/content/asm_3.md
@@ -14,23 +14,23 @@ global _start
 section .text
 
 _start:
-	;; Put 1 to the rax register
-	mov rax, 1
-	;; Call the incRax subroutine
-	call incRax
-	;; Compare the value in the rax register with 2
-	cmp rax, 2
-	;; Jump to the 'exit' label if not equal
-	jne exit
-	;;
-	;; Otherwise, perform another action.
-	;;
+        ;; Put 1 to the rax register
+        mov rax, 1
+        ;; Call the incRax subroutine
+        call incRax
+        ;; Compare the value in the rax register with 2
+        cmp rax, 2
+        ;; Jump to the 'exit' label if not equal
+        jne exit
+        ;;
+        ;; Otherwise, perform another action.
+        ;;
 
 incRax:
-	;; Increment the value of the rax register
-	inc rax
-	;; Return from the incRax subroutine
-	ret
+        ;; Increment the value of the rax register
+        inc rax
+        ;; Return from the incRax subroutine
+        ret
 ```
 
 In the example above, we can see that after the program starts, the value `1` is stored in the `rax` register. Next, we call the subroutine `incRax`, which increases the value in the `rax` register by 1. After updating the `rax` register, the subroutine ends with the `ret` instruction, and execution continues with the instructions immediately following the call to the `incRax` subroutine.
@@ -61,23 +61,23 @@ If we compile this function and take a look at the assembly output, we will see 
 
 ```assembly
 __double(int):
-	;; Preserve the base pointer
-	push rbp
-	;; Set the new frame base pointer
-	mov rbp, rsp
-	;; Put the value of the first parameter of the function from the edi register
-	;; on the stack with the location rbp - 20 bytes.
-	mov DWORD PTR [rbp-20], edi
-	;; Put 2 to on the stack with the location rbp - 4 bytes.
-	mov DWORD PTR [rbp-4], 2
-	;; Put the value of the first function parameter to the eax register.
-	mov eax, DWORD PTR [rbp-20]
-	;; Multiple the value of the eax register to 2 and store the result in the eax register.
-	imul eax, DWORD PTR [rbp-4]
-	;; Restore base pointer.
-	pop rbp
-	;; Exit from the __dobule function.
-	ret
+        ;; Preserve the base pointer
+        push rbp
+        ;; Set the new frame base pointer
+        mov rbp, rsp
+        ;; Put the value of the first parameter of the function from the edi register
+        ;; on the stack with the location rbp - 20 bytes.
+        mov DWORD PTR [rbp-20], edi
+        ;; Put 2 to on the stack with the location rbp - 4 bytes.
+        mov DWORD PTR [rbp-4], 2
+        ;; Put the value of the first function parameter to the eax register.
+        mov eax, DWORD PTR [rbp-20]
+        ;; Multiple the value of the eax register to 2 and store the result in the eax register.
+        imul eax, DWORD PTR [rbp-4]
+        ;; Restore base pointer.
+        pop rbp
+        ;; Exit from the __dobule function.
+        ret
 ```
 
 After the first two lines of the `__double` function, the stack frame for this function is set and looks like this:
@@ -106,17 +106,17 @@ In the [previous post](asm_2.md), we became familiar with concepts such as the [
 
 ```assembly
 foo:
-	;; Function prologue
-	push rbp
-	mov  rbp, rsp
+        ;; Function prologue
+        push rbp
+        mov  rbp, rsp
 
-	;;
-	;; Function body
-	;;
+        ;;
+        ;; Function body
+        ;;
 
-	;; Function epilogue
-	mov rsp, rbp
-	pop
+        ;; Function epilogue
+        mov rsp, rbp
+        pop
 ```
 
 These two can be replaced with special instructions: `enter N, 0` and `leave`. The `enter` instruction has two operands:
@@ -145,165 +145,165 @@ Before diving into details, let's first examine the entire code:
 ```assembly
 ;; Definition of the .data section
 section .data
-	;; Number of the `sys_write` system call
-	SYS_WRITE equ 1
-	;; Number of the `sys_exit` system call
-	SYS_EXIT equ 60
-	;; Number of the standard output file descriptor
-	STD_OUT	equ 1
-	;; Exit code from the program. The 0 status code is a success.
-	EXIT_CODE equ 0
-	;; ASCII code of the new line symbol ('\n')
-	NEW_LINE db 0xa
-	;; Error message that is printed in a case of not enough command-line arguments
-	WRONG_ARGC_MSG	db "Error: expected two command-line arguments", 0xa
-	;; Length of the WRONG_ARGC_MSG message
-	WRONG_ARGC_MSG_LEN equ 42
+        ;; Number of the `sys_write` system call
+        SYS_WRITE equ 1
+        ;; Number of the `sys_exit` system call
+        SYS_EXIT equ 60
+        ;; Number of the standard output file descriptor
+        STD_OUT equ 1
+        ;; Exit code from the program. The 0 status code is a success.
+        EXIT_CODE equ 0
+        ;; ASCII code of the new line symbol ('\n')
+        NEW_LINE db 0xa
+        ;; Error message that is printed in a case of not enough command-line arguments
+        WRONG_ARGC_MSG  db "Error: expected two command-line arguments", 0xa
+        ;; Length of the WRONG_ARGC_MSG message
+        WRONG_ARGC_MSG_LEN equ 42
 
 ;; Definition of the .text section
 section .text
-	;; Reference to the entry point of our program
-	global	_start
+        ;; Reference to the entry point of our program
+        global _start
 
 ;; Entry point
 _start:
-	;; Fetch the number of arguments from the stack and store it in the rcx register.
-	pop rcx
-	;; Check the number of the given command-line arguments.
-	cmp rcx, 3
-	;; If not enough, jump to the error subroutine.
-	jne argcError
+        ;; Fetch the number of arguments from the stack and store it in the rcx register.
+        pop rcx
+        ;; Check the number of the given command-line arguments.
+        cmp rcx, 3
+        ;; If not enough, jump to the error subroutine.
+        jne argcError
 
-	;; Skip the first command-line argument which is usually the program name.
-	add rsp, 8
+        ;; Skip the first command-line argument which is usually the program name.
+        add rsp, 8
 
-	;; Fetch the first command-line argument from the stack and store it in the rsi register.
-	pop rsi
-	;; Convert the first command-line argument to an integer number.
-	call str_to_int
-	;; Store the result in the r10 register.
-	mov r10, rax
+        ;; Fetch the first command-line argument from the stack and store it in the rsi register.
+        pop rsi
+        ;; Convert the first command-line argument to an integer number.
+        call str_to_int
+        ;; Store the result in the r10 register.
+        mov r10, rax
 
-	;; Fetch the second command-line argument from the stack and store it in the rsi register.
-	pop rsi
-	;; Convert the second command-line argument to an integer number.
-	call str_to_int
-	;; Store the result in the r11 register.
-	mov r11, rax
+        ;; Fetch the second command-line argument from the stack and store it in the rsi register.
+        pop rsi
+        ;; Convert the second command-line argument to an integer number.
+        call str_to_int
+        ;; Store the result in the r11 register.
+        mov r11, rax
 
-	;; Calculate the sum of the arguments. The result will be stored in the r10 register.
-	add r10, r11
-	;; Move the sum value to the rax register.
-	mov rax, r10
-	;; Initialize counter by resetting it to 0. It will store the length of the result string.
-	xor rcx, rcx
-	;; Convert the sum from a number to a string to print the result to the standard output.
-	jmp int_to_str
+        ;; Calculate the sum of the arguments. The result will be stored in the r10 register.
+        add r10, r11
+        ;; Move the sum value to the rax register.
+        mov rax, r10
+        ;; Initialize counter by resetting it to 0. It will store the length of the result string.
+        xor rcx, rcx
+        ;; Convert the sum from a number to a string to print the result to the standard output.
+        jmp int_to_str
 
 ;; Print the error message if not enough command-line arguments.
 argcError:
-	;; Specify the system call number (1 is `sys_write`).
-	mov rax, SYS_WRITE
-	;; Set the first argument of `sys_write` to 1 (`stdout`).
-	mov rdi, STD_OUT
-	;; Set the second argument of `sys_write` to the reference of the `WRONG_ARGC_MSG` variable.
-	mov rsi, WRONG_ARGC_MSG
-	;; Set the third argument to the length of the `WRONG_ARGC_MSG` variable's value.
-	mov rdx, WRONG_ARGC_MSG_LEN
-	;; Call the `sys_write` system call.
-	syscall
-	;; Go to the exit of the program.
-	jmp exit
+        ;; Specify the system call number (1 is `sys_write`).
+        mov rax, SYS_WRITE
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, STD_OUT
+        ;; Set the second argument of `sys_write` to the reference of the `WRONG_ARGC_MSG` variable.
+        mov rsi, WRONG_ARGC_MSG
+        ;; Set the third argument to the length of the `WRONG_ARGC_MSG` variable's value.
+        mov rdx, WRONG_ARGC_MSG_LEN
+        ;; Call the `sys_write` system call.
+        syscall
+        ;; Go to the exit of the program.
+        jmp exit
 
 ;; Convert the command-line argument to the integer number.
 str_to_int:
-	;; Set the value of the rax register to 0. It will store the result.
-	xor rax, rax
-	;; Base for multiplication
-	mov rcx,  10
+        ;; Set the value of the rax register to 0. It will store the result.
+        xor rax, rax
+        ;; Base for multiplication
+        mov rcx, 10
 __repeat:
-	;; Compare the first element in the given string with the `NUL` terminator (end of the string).
-	cmp [rsi], byte 0
-	;; If we reached the end of the string, return from the procedure. The result is stored in the rax register.
-	je __return
-	;; Move the current character from the command-line argument to the bl register.
-	mov bl, [rsi]
-	;; Subtract the value 48 from the ASCII code of the current character.
-	;; This will give us the numeric value of the character.
-	sub bl, 48
-	;; Multiple our result number by 10 to get the place for the next digit.
-	mul rcx
-	;; Add the next digit to our result number.
-	add rax, rbx
-	;; Move to the next character in the command-line argument string.
-	inc rsi
-	;; Repeat until we reach the end of the string.
-	jmp __repeat
+        ;; Compare the first element in the given string with the `NUL` terminator (end of the string).
+        cmp [rsi], byte 0
+        ;; If we reached the end of the string, return from the procedure. The result is stored in the rax register.
+        je __return
+        ;; Move the current character from the command-line argument to the bl register.
+        mov bl, [rsi]
+        ;; Subtract the value 48 from the ASCII code of the current character.
+        ;; This will give us the numeric value of the character.
+        sub bl, 48
+        ;; Multiple our result number by 10 to get the place for the next digit.
+        mul rcx
+        ;; Add the next digit to our result number.
+        add rax, rbx
+        ;; Move to the next character in the command-line argument string.
+        inc rsi
+        ;; Repeat until we reach the end of the string.
+        jmp __repeat
 __return:
-	;; Return from the str_to_int procedure.
-	ret
+        ;; Return from the str_to_int procedure.
+        ret
 
 ;; Convert the sum to a string and print it to the standard output.
 int_to_str:
-	;; High part of the dividend. The low part is in the rax register.
-	mov rdx, 0
-	;; Set the divisor to 10.
-	mov rbx, 10
-	;; Divide the sum stored in `rax`, resulting quotient will be stored in `rax`,
-	;; and the reminder will be stored in `rdx` register.
-	div rbx
-	;; Add 48 to the reminder to get a string ASCII representation of the number value.
-	add rdx, 48
-	;; Store the reminder on the stack.
-	push rdx
-	;; Increase the counter.
-	inc rcx
-	;; Compare the rest of the sum with zero.
-	cmp rax, 0x0
-	;; If it is not zero, continue to convert it to string.
-	jne int_to_str
-	;; Otherwise, print the result.
-	jmp printResult
+        ;; High part of the dividend. The low part is in the rax register.
+        mov rdx, 0
+        ;; Set the divisor to 10.
+        mov rbx, 10
+        ;; Divide the sum stored in `rax`, resulting quotient will be stored in `rax`,
+        ;; and the reminder will be stored in `rdx` register.
+        div rbx
+        ;; Add 48 to the reminder to get a string ASCII representation of the number value.
+        add rdx, 48
+        ;; Store the reminder on the stack.
+        push rdx
+        ;; Increase the counter.
+        inc rcx
+        ;; Compare the rest of the sum with zero.
+        cmp rax, 0x0
+        ;; If it is not zero, continue to convert it to string.
+        jne int_to_str
+        ;; Otherwise, print the result.
+        jmp printResult
 
 ;; Print the result to the standard output.
 printResult:
-	;; Put the number of string characters to the rax register.
-	mov rax, rcx
-	;; Put the value 8 to the rcx register.
-	mov rcx, 8
-	;; Calculate the number of bytes in the given string by multiplying rax by 8.
-	;; The result will be stored in the rax register.
-	mul rcx
+        ;; Put the number of string characters to the rax register.
+        mov rax, rcx
+        ;; Put the value 8 to the rcx register.
+        mov rcx, 8
+        ;; Calculate the number of bytes in the given string by multiplying rax by 8.
+        ;; The result will be stored in the rax register.
+        mul rcx
 
-	;; Set the third argument to the length of the result string to print.
-	mov rdx, rax
-	;; Specify the system call number (1 is `sys_write`).
-	mov rax, SYS_WRITE
-	;; Set the first argument of `sys_write` to 1 (`stdout`).
-	mov rdi, STD_OUT
-	;; Set the second argument of `sys_write` to the reference of the result string to print.
-	mov rsi, rsp
-	;; Call the `sys_write` system call.
-	syscall
+        ;; Set the third argument to the length of the result string to print.
+        mov rdx, rax
+        ;; Specify the system call number (1 is `sys_write`).
+        mov rax, SYS_WRITE
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, STD_OUT
+        ;; Set the second argument of `sys_write` to the reference of the result string to print.
+        mov rsi, rsp
+        ;; Call the `sys_write` system call.
+        syscall
 
-	;; Specify the system call number (1 is `sys_write`).
-	mov rax, SYS_WRITE
-	;; Set the first argument of `sys_write` to 1 (`stdout`).
-	mov rdi, STD_OUT
-	;; Set the second argument of `sys_write` to the reference of the `NWE_LINE` variable.
-	mov rsi, NEW_LINE
-	;; Set the third argument to the length of the `NEW_LINE` variable's value (1 byte).
-	mov rdx, 1
-	;; Call the `sys_write` system call.
-	syscall
+        ;; Specify the system call number (1 is `sys_write`).
+        mov rax, SYS_WRITE
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, STD_OUT
+        ;; Set the second argument of `sys_write` to the reference of the `NWE_LINE` variable.
+        mov rsi, NEW_LINE
+        ;; Set the third argument to the length of the `NEW_LINE` variable's value (1 byte).
+        mov rdx, 1
+        ;; Call the `sys_write` system call.
+        syscall
 
 exit:
-	;; Specify the number of the system call (60 is `sys_exit`).
-	mov rax, SYS_EXIT
-	;; Set the first argument of `sys_exit` to 0. The 0 status code is a success.
-	mov rdi, EXIT_CODE
-	;; Call the `sys_exit` system call.
-	syscall
+        ;; Specify the number of the system call (60 is `sys_exit`).
+        mov rax, SYS_EXIT
+        ;; Set the first argument of `sys_exit` to 0. The 0 status code is a success.
+        mov rdi, EXIT_CODE
+        ;; Call the `sys_exit` system call.
+        syscall
 ```
 
 Yes, this example might seem quite big for such a simple problem 😨 But do not worry — the code is well-documented with comments. Let’s go through its parts and understand how it works.
@@ -314,20 +314,20 @@ At the beginning of our program, we can see a typical definition of the `.data` 
 
 ```assembly
 section .data
-	;; Number of the `sys_write` system call
-	SYS_WRITE equ 1
-	;; Number of the `sys_exit` system call
-	SYS_EXIT equ 60
-	;; Number of the standard output file descriptor
-	STD_OUT	equ 1
-	;; Exit code from the program. The 0 status code is a success.
-	EXIT_CODE equ 0
-	;; ASCII code of the new line symbol ('\n')
-	NEW_LINE db 0xa
-	;; Error message that is printed in a case of not enough command-line arguments
-	WRONG_ARGC_MSG	db "Error: expected two command-line argument", 0xa
-	;; Length of the WRONG_ARGC_MSG message
-	WRONG_ARGC_MSG_LEN equ 42
+        ;; Number of the `sys_write` system call
+        SYS_WRITE equ 1
+        ;; Number of the `sys_exit` system call
+        SYS_EXIT equ 60
+        ;; Number of the standard output file descriptor
+        STD_OUT equ 1
+        ;; Exit code from the program. The 0 status code is a success.
+        EXIT_CODE equ 0
+        ;; ASCII code of the new line symbol ('\n')
+        NEW_LINE db 0xa
+        ;; Error message that is printed in a case of not enough command-line arguments
+        WRONG_ARGC_MSG  db "Error: expected two command-line argument", 0xa
+        ;; Length of the WRONG_ARGC_MSG message
+        WRONG_ARGC_MSG_LEN equ 42
 ```
 
 As we know from the previous posts, the main purpose of the `data` section is to define variables that have initialized values. This example is no exception. Here, we define the system call number variables, string error messages, and more. This code sample contains comments with descriptions, so everything should generally be clear. If something is unclear, it’s a good idea to revisit the previous posts for clarification before you proceed with the rest of the explanation.
@@ -359,32 +359,32 @@ As we can see, the number of command-line arguments passed to the program is sto
 ```assembly
 ;; Definition of the .text section
 section .text
-	;; Reference to the entry point of our program
-	global	_start
+        ;; Reference to the entry point of our program
+        global _start
 
 ;; Entry point
 _start:
-	;; Fetch the number of arguments from the stack and store it in the rcx register.
-	pop rcx
-	;; Check the number of the given command-line arguments.
-	cmp rcx, 3
-	;; If not enough, jump to the error subroutine.
-	jne argcError
+        ;; Fetch the number of arguments from the stack and store it in the rcx register.
+        pop rcx
+        ;; Check the number of the given command-line arguments.
+        cmp rcx, 3
+        ;; If not enough, jump to the error subroutine.
+        jne argcError
 
 ;; Print the error message if not enough command-line arguments.
 argcError:
-	;; Specify the system call number (1 is `sys_write`).
-	mov rax, SYS_WRITE
-	;; Set the first argument of `sys_write` to 1 (`stdout`).
-	mov rdi, STD_OUT
-	;; Set the second argument of `sys_write` to the reference of the `WRONG_ARGC_MSG` variable.
-	mov rsi, WRONG_ARGC_MSG
-	;; Set the third argument to the length of the `WRONG_ARGC_MSG` variable's value.
-	mov rdx, WRONG_ARGC_MSG_LEN
-	;; Call the `sys_write` system call.
-	syscall
-	;; Go to the exit of the program.
-	jmp exit
+        ;; Specify the system call number (1 is `sys_write`).
+        mov rax, SYS_WRITE
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, STD_OUT
+        ;; Set the second argument of `sys_write` to the reference of the `WRONG_ARGC_MSG` variable.
+        mov rsi, WRONG_ARGC_MSG
+        ;; Set the third argument to the length of the `WRONG_ARGC_MSG` variable's value.
+        mov rdx, WRONG_ARGC_MSG_LEN
+        ;; Call the `sys_write` system call.
+        syscall
+        ;; Go to the exit of the program.
+        jmp exit
 ```
 
 Note that although we expect two command-line arguments, we compare the actual number with `3`. This is because the first implicit argument for every program is its name.
@@ -410,58 +410,58 @@ Returning to the table from the section above, we can see that pointers to the c
 Now the `str_to_int` procedure should be more clear:
 
 ```assembly
-	;; Fetch the first command-line argument from the stack and store it in the rsi register.
-	pop rsi
-	;; Convert the first command-line argument to an integer number.
-	call str_to_int
-	;; Store the result in the r10 register.
-	mov r10, rax
+        ;; Fetch the first command-line argument from the stack and store it in the rsi register.
+        pop rsi
+        ;; Convert the first command-line argument to an integer number.
+        call str_to_int
+        ;; Store the result in the r10 register.
+        mov r10, rax
 
-	;; Fetch the second command-line argument from the stack and store it in the rsi register.
-	pop rsi
-	;; Convert the second command-line argument to an integer number.
-	call str_to_int
-	;; Store the result in the r11 register.
-	mov r11, rax
+        ;; Fetch the second command-line argument from the stack and store it in the rsi register.
+        pop rsi
+        ;; Convert the second command-line argument to an integer number.
+        call str_to_int
+        ;; Store the result in the r11 register.
+        mov r11, rax
 
-	...
-	...
-	...
+        ...
+        ...
+        ...
 
 ;; Convert the command-line argument to the integer number.
 str_to_int:
-	;; Set the value of the rax register to 0. It will store the result.
-	xor rax, rax
-	;; Base for multiplication
-	mov rcx,  10
+        ;; Set the value of the rax register to 0. It will store the result.
+        xor rax, rax
+        ;; Base for multiplication
+        mov rcx, 10
 __repeat:
-	;; Compare the first element in the given string with the `NUL` terminator (end of the string).
-	cmp [rsi], byte 0
-	;; If we reached the end of the string, return from the procedure. The result is stored in the rax register.
-	je __return
-	;; Move the current character from the command-line argument to the bl register.
-	mov bl, [rsi]
-	;; Subtract the value 48 from the ASCII code of the current character.
-	;; This will give us the numeric value of the character.
-	sub bl, 48
-	;; Multiple our result number by 10 to get the place for the next digit.
-	mul rcx
-	;; Add the next digit to our result number.
-	add rax, rbx
-	;; Move to the next character in the command-line argument string.
-	inc rsi
-	;; Repeat until we reach the end of the string.
-	jmp __repeat
+        ;; Compare the first element in the given string with the `NUL` terminator (end of the string).
+        cmp [rsi], byte 0
+        ;; If we reached the end of the string, return from the procedure. The result is stored in the rax register.
+        je __return
+        ;; Move the current character from the command-line argument to the bl register.
+        mov bl, [rsi]
+        ;; Subtract the value 48 from the ASCII code of the current character.
+        ;; This will give us the numeric value of the character.
+        sub bl, 48
+        ;; Multiple our result number by 10 to get the place for the next digit.
+        mul rcx
+        ;; Add the next digit to our result number.
+        add rax, rbx
+        ;; Move to the next character in the command-line argument string.
+        inc rsi
+        ;; Repeat until we reach the end of the string.
+        jmp __repeat
 __return:
-	;; Return from the str_to_int procedure.
-	ret
+        ;; Return from the str_to_int procedure.
+        ret
 ```
 
 As soon as we converted both command-line arguments to integer numbers, we can calculate their sum:
 
 ```assembly
-	;; Calculate the sum of the arguments. The result will be stored in the r10 register.
-	add r10, r11
+        ;; Calculate the sum of the arguments. The result will be stored in the r10 register.
+        add r10, r11
 ```
 
 Now that we have our result, we just need to print it. But before printing it, we have to convert the numeric result back to a string.
@@ -471,36 +471,36 @@ Now that we have our result, we just need to print it. But before printing it, w
 In the previous section, we calculated the sum of two numbers and put the result in the `r10` register. As the `sys_write` system call can only print a string, now we need to convert our numeric sum into a string. To do so, we will use the `int_to_str` subroutine:
 
 ```assembly
-	;; Move the sum value to the rax register.
-	mov rax, r10
-	;; Initialize counter by resetting it to 0. It will store the length of the result string.
-	xor rcx, rcx
-	;; Convert the sum from a number to a string to print the result to the standard output.
-	jmp int_to_str
+        ;; Move the sum value to the rax register.
+        mov rax, r10
+        ;; Initialize counter by resetting it to 0. It will store the length of the result string.
+        xor rcx, rcx
+        ;; Convert the sum from a number to a string to print the result to the standard output.
+        jmp int_to_str
 
 ;; Convert the sum to a string and print it to the standard output.
 int_to_str:
-	;; High part of the dividend. The low part is in the rax register.
-	;; The div instruction works as div operand => rdx:rax / operand.
-	;; The reminder is stored in rdx and the quotient in rax.
-	mov rdx, 0
-	;; Set the divisor to 10.
-	mov rbx, 10
-    ;; Divide the sum stored in `rax. The resulting quotient will be stored in `rax`,
-	;; and the reminder will be stored in the `rdx` register.
-	div rbx
-	;; Add 48 to the reminder to get a string ASCII representation of the number value.
-	add rdx, 48
-	;; Store the reminder on the stack.
-	push rdx
-	;; Increase the counter.
-	inc rcx
-	;; Compare the rest of the sum with zero.
-	cmp rax, 0x0
-	;; If it is not zero, continue to convert it to string.
-	jne int_to_str
-	;; Otherwise, print the result.
-	jmp printResult
+        ;; High part of the dividend. The low part is in the rax register.
+        ;; The div instruction works as div operand => rdx:rax / operand.
+        ;; The reminder is stored in rdx and the quotient in rax.
+        mov rdx, 0
+        ;; Set the divisor to 10.
+        mov rbx, 10
+        ;; Divide the sum stored in `rax. The resulting quotient will be stored in `rax`,
+        ;; and the reminder will be stored in the `rdx` register.
+        div rbx
+        ;; Add 48 to the reminder to get a string ASCII representation of the number value.
+        add rdx, 48
+        ;; Store the reminder on the stack.
+        push rdx
+        ;; Increase the counter.
+        inc rcx
+        ;; Compare the rest of the sum with zero.
+        cmp rax, 0x0
+        ;; If it is not zero, continue to convert it to string.
+        jne int_to_str
+        ;; Otherwise, print the result.
+        jmp printResult
 ```
 
 Before jumping to the `int_to_str` subroutine, we must prepare the data with two instructions:
@@ -519,43 +519,43 @@ Once we collect all the digits of the sum, they will be stored on the stack. Now
 ```assembly
 ;; Print the result to the standard output.
 printResult:
-	;; Put the number of string characters to the rax register.
-	mov rax, rcx
-	;; Put the value 8 to the rcx register.
-	mov rcx, 8
-	;; Calculate the number of bytes in the given string by multiplying rax by 8.
-	;; The result will be stored in the rax register.
-	mul rcx
+        ;; Put the number of string characters to the rax register.
+        mov rax, rcx
+        ;; Put the value 8 to the rcx register.
+        mov rcx, 8
+        ;; Calculate the number of bytes in the given string by multiplying rax by 8.
+        ;; The result will be stored in the rax register.
+        mul rcx
 
-	;; Set the third argument to the length of the result string to print.
-	mov rdx, rax
-	;; Specify the system call number (1 is `sys_write`).
-	mov rax, SYS_WRITE
-	;; Set the first argument of `sys_write` to 1 (`stdout`).
-	mov rdi, STD_OUT
-	;; Set the second argument of `sys_write` to the reference of the result string to print.
-	mov rsi, rsp
-	;; Call the `sys_write` system call.
-	syscall
+        ;; Set the third argument to the length of the result string to print.
+        mov rdx, rax
+        ;; Specify the system call number (1 is `sys_write`).
+        mov rax, SYS_WRITE
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, STD_OUT
+        ;; Set the second argument of `sys_write` to the reference of the result string to print.
+        mov rsi, rsp
+        ;; Call the `sys_write` system call.
+        syscall
 
-	;; Specify the system call number (1 is `sys_write`).
-	mov rax, SYS_WRITE
-	;; Set the first argument of `sys_write` to 1 (`stdout`).
-	mov rdi, STD_OUT
-	;; Set the second argument of `sys_write` to the reference of the `NWE_LINE` variable.
-	mov rsi, NEW_LINE
-	;; Set the third argument to the length of the `NEW_LINE` variable's value (1 byte).
-	mov rdx, 1
-	;; Call the `sys_write` system call.
-	syscall
+        ;; Specify the system call number (1 is `sys_write`).
+        mov rax, SYS_WRITE
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, STD_OUT
+        ;; Set the second argument of `sys_write` to the reference of the `NWE_LINE` variable.
+        mov rsi, NEW_LINE
+        ;; Set the third argument to the length of the `NEW_LINE` variable's value (1 byte).
+        mov rdx, 1
+        ;; Call the `sys_write` system call.
+        syscall
 
 exit:
-	;; Specify the number of the system call (60 is `sys_exit`).
-	mov rax, SYS_EXIT
-	;; Set the first argument of `sys_exit` to 0. The 0 status code is a success.
-	mov rdi, EXIT_CODE
-	;; Call the `sys_exit` system call.
-	syscall
+        ;; Specify the number of the system call (60 is `sys_exit`).
+        mov rax, SYS_EXIT
+        ;; Set the first argument of `sys_exit` to 0. The 0 status code is a success.
+        mov rdi, EXIT_CODE
+        ;; Call the `sys_exit` system call.
+        syscall
 ```
 
 Most of this code should already be understandable, as it mainly consists of the data initialization for the `sys_write` and `sys_exit` system calls. Both of them we already have seen in two previous chapters. The most interesting part is the first four lines of the `printResult` subroutine. As you may remember, one of the parameters of the `sys_write` system call is the length of the string we want to print to the standard output. We have this number because we maintained a counter of characters while converting the numeric sum to a string. This counter was stored in the `rcx` register. Our string is located on the stack, where we pushed each digit using the `push` instruction. However, the `push` instruction pushes `64` bits (or `8` bytes), while our symbol is only 1 byte. To calculate the total length of the string for printing, we should multiply the number of symbols by `8`. This will give us the length of the string that we can use as the third argument of the `sys_write` system call.

--- a/content/asm_4.md
+++ b/content/asm_4.md
@@ -174,7 +174,7 @@ Next, we define the `.bss` section for our buffer where we will put the reversed
 ;; Definition of the .bss section.
 section .bss
         ;; Output buffer where the reversed string will be stored.
-        OUTPUT  resb 1
+        OUTPUT resb 1
 ```
 
 After we defined the data needed to build our program, we can define the `.text` section:

--- a/content/asm_5.md
+++ b/content/asm_5.md
@@ -8,11 +8,11 @@ If you already have some programming experience in other languages, you’ve lik
 
 - Text substitution. These are the macros you may find in C or C++ programming languages. They perform a simple text replacement before code compilation happens. This leads to a situation where the compiler operates with the results of the macros, not the macros themselves. For example:
 
-   ```C
-   #define SQUARE(x) (x * x)
+```C
+#define SQUARE(x) (x * x)
 
-   int x = SQUARE(5); // will be replaced with 5 * 5
-   ```
+int x = SQUARE(5); // will be replaced with 5 * 5
+```
 
 - Macros that operate at the code structure level, such as [lisp](https://lispcookbook.github.io/cl-cookbook/macros.html) or [rust](https://doc.rust-lang.org/book/ch20-05-macros.html) macros. This type of macro generates code by manipulating or expanding parts of the language’s syntax tree.
 
@@ -70,12 +70,13 @@ A definition of a multi-line macro starts with the `%macro` NASM directive and e
 
 ```assembly
 %macro name number_of_parameters
-    instruction
-    instruction
-    instruction
-    ...
-    ...
-    ...
+        instruction1
+        instruction2
+        instruction3
+        ...
+        ...
+        ...
+        instructionN
 %endmacro
 ```
 
@@ -131,11 +132,11 @@ After we have defined our macros, we can use them in our code. For example:
 ;; Definition of the .data section.
 section .data
         ;; The first message to print.
-        msg_1   db      "Message 1"
+        msg_1 db "Message 1"
         ;; The second message to print.
-        msg_2   db      "Message 2"
+        msg_2 db "Message 2"
         ;; ASCII code of the new line symbol ('\n').
-        newline db      0xA
+        newline db 0xA
 
 ;; Definition of the .text section.
 section .text
@@ -174,8 +175,9 @@ Another syntax ability in the multi-line NASM macros is the possibility to defin
         jg %%label
         ret
 %%label:
-        ...
-        ...
+        instruction1
+        instruction2
+        instruction3
         ...
 %endmacro
 ```
@@ -367,10 +369,10 @@ section .data
         newline: db 0xA
         ;; Instance of the person structure.
         p: istruc person
-           ;; Person name
-           at person.name, db "Alex"
-           ;; Person age
-           at person.age,  db 25
+                ;; Person name
+                at person.name, db "Alex"
+                ;; Person age
+                at person.age,  db 25
         iend
 
 ;; Definition of the .text section.
@@ -398,10 +400,10 @@ Let's take a look at the definition of the macro `REPX` defined in the [x86inc.a
 ;; Repeats an instruction/operation for multiple arguments.
 ;; Example usage: "REPX {psrlw x, 8}, m0, m1, m2, m3"
 %macro REPX 2-* ; operation, args
-    %xdefine %%f(x) %1
-    %rep %0 - 1
-        %rotate 1
-        %%f(%1)
+        %xdefine %%f(x) %1
+        %rep %0 - 1
+                %rotate 1
+                %%f(%1)
     %endrep
 %endmacro
 ```

--- a/content/asm_5.md
+++ b/content/asm_5.md
@@ -8,11 +8,11 @@ If you already have some programming experience in other languages, you’ve lik
 
 - Text substitution. These are the macros you may find in C or C++ programming languages. They perform a simple text replacement before code compilation happens. This leads to a situation where the compiler operates with the results of the macros, not the macros themselves. For example:
 
-```C
-#define SQUARE(x) (x * x)
+    ```C
+    #define SQUARE(x) (x * x)
 
-int x = SQUARE(5); // will be replaced with 5 * 5
-```
+    int x = SQUARE(5); // will be replaced with 5 * 5
+    ```
 
 - Macros that operate at the code structure level, such as [lisp](https://lispcookbook.github.io/cl-cookbook/macros.html) or [rust](https://doc.rust-lang.org/book/ch20-05-macros.html) macros. This type of macro generates code by manipulating or expanding parts of the language’s syntax tree.
 

--- a/content/asm_6.md
+++ b/content/asm_6.md
@@ -473,12 +473,12 @@ _error:
 
 ;; Exit from the program.
 _exit:
-    ;; Specify the number of the system call (60 is `sys_exit`).
-    mov rax, SYS_EXIT
-    ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
-    mov rdi, EXIT_CODE
-    ;; Call the `sys_exit` system call.
-    syscall
+        ;; Specify the number of the system call (60 is `sys_exit`).
+        mov rax, SYS_EXIT
+        ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
+        mov rdi, EXIT_CODE
+        ;; Call the `sys_exit` system call.
+        syscall
 ```
 
 If both vectors have the same number of components, we can proceed to the calculation. To do that, we store the addresses of both vectors in the `rdi` and `rsi` registers, and put the number of components within the vectors into the `rdx` register. The `_dot_product` function does the main job. Let's take a look at the code of this function:

--- a/content/asm_7.md
+++ b/content/asm_7.md
@@ -17,33 +17,33 @@ Let's go back to the [`hello world`](./asm_1.md) example from the very first cha
 ```assembly
 ;; Definition of the `data` section
 section .data
-    ;; String variable with the value `hello world!`
-    msg db "hello, world!"
+        ;; String variable with the value `hello world!`
+        msg db "hello, world!"
 
 ;; Definition of the text section
 section .text
-    ;; Reference to the entry point of our program
-    global _start
+        ;; Reference to the entry point of our program
+        global _start
 
 ;; Entry point
 _start:
-    ;; Specify the number of the system call (1 is `sys_write`).
-    mov rax, 1
-    ;; Set the first argument of `sys_write` to 1 (`stdout`).
-    mov rdi, 1
-    ;; Set the second argument of `sys_write` to the reference of the `msg` variable.
-    mov rsi, msg
-    ;; Set the third argument of `sys_write` to the length of the `msg` variable's value (13 bytes).
-    mov rdx, 13
-    ;; Call the `sys_write` system call.
-    syscall
+        ;; Specify the number of the system call (1 is `sys_write`).
+        mov rax, 1
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, 1
+        ;; Set the second argument of `sys_write` to the reference of the `msg` variable.
+        mov rsi, msg
+        ;; Set the third argument of `sys_write` to the length of the `msg` variable's value (13 bytes).
+        mov rdx, 13
+        ;; Call the `sys_write` system call.
+        syscall
 
-    ;; Specify the number of the system call (60 is `sys_exit`).
-    mov rax, 60
-    ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
-    mov rdi, 0
-    ;; Call the `sys_exit` system call.
-    syscall
+        ;; Specify the number of the system call (60 is `sys_exit`).
+        mov rax, 60
+        ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
+        mov rdi, 0
+        ;; Call the `sys_exit` system call.
+        syscall
 ```
 
 Basically, this example only contains an invocation of two [system calls](https://en.wikipedia.org/wiki/System_call):
@@ -61,32 +61,32 @@ Let's take a look at the implementation:
 ```assembly
 ;; Definition of the `data` section
 section .data
-    ;; String variable with the value `hello world!`
-    msg db "hello, world!"
+        ;; String variable with the value `hello world!`
+        msg db "hello, world!"
 
-    ;; Reference to the C stdlib functions that we will use
-    extern write, exit
+        ;; Reference to the C stdlib functions that we will use
+        extern write, exit
 
 ;; Definition of the text section
 section .text
-    ;; Reference to the entry point of our program
-    global _start
+        ;; Reference to the entry point of our program
+        global _start
 
 ;; Entry point
 _start:
-    ;; Set the first argument of the `write` function to 1 (`stdout`).
-    mov rdi, 1
-    ;; Set the second argument of the `write` function to the reference of the `msg` variable.
-    mov rsi, msg
-    ;; Set the third argument to the length of the `msg` variable's value (13 bytes).
-    mov rdx, 13
-    ;; Call the `write` function.
-    call write
+        ;; Set the first argument of the `write` function to 1 (`stdout`).
+        mov rdi, 1
+        ;; Set the second argument of the `write` function to the reference of the `msg` variable.
+        mov rsi, msg
+        ;; Set the third argument to the length of the `msg` variable's value (13 bytes).
+        mov rdx, 13
+        ;; Call the `write` function.
+        call write
 
-    ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
-    mov rdi, 0
-    ;; Call the `exit` function
-    call exit
+        ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
+        mov rdi, 0
+        ;; Call the `exit` function
+        call exit
 ```
 
 The logic of this program looks pretty similar to the example above. The main difference is that we use the `call` instruction with the function name instead of the `syscall` instruction. In addition, you may note that since we are using the functions from the standard library, we do not need to specify the number of the system call anymore. The general-purpose registers that we use to pass function parameters also look pretty similar, but there is a difference as well. The following registers are used to pass parameters to the non-system call functions:

--- a/float/dot_product.asm
+++ b/float/dot_product.asm
@@ -295,9 +295,9 @@ _error:
 
 ;; Exit from the program.
 _exit:  
-    ;; Specify the number of the system call (60 is `sys_exit`).
-    mov rax, SYS_EXIT
-    ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
-    mov rdi, EXIT_CODE
-    ;; Call the `sys_exit` system call.
-    syscall
+        ;; Specify the number of the system call (60 is `sys_exit`).
+        mov rax, SYS_EXIT
+        ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
+        mov rdi, EXIT_CODE
+        ;; Call the `sys_exit` system call.
+        syscall

--- a/hello/hello.asm
+++ b/hello/hello.asm
@@ -1,29 +1,29 @@
 ;; Definition of the `data` section
 section .data
-    ;; String variable with the value `hello world!`
-    msg db      "hello, world!"
+        ;; String variable with the value `hello world!`
+        msg db "hello, world!"
 
 ;; Definition of the text section
 section .text
-    ;; Reference to the entry point of our program
-    global _start
+        ;; Reference to the entry point of our program
+        global _start
 
 ;; Entry point
 _start:
-    ;; Specify the number of the system call (1 is `sys_write`).
-    mov     rax, 1
-    ;; Set the first argument of `sys_write` to 1 (`stdout`).
-    mov     rdi, 1
-    ;; Set the second argument of `sys_write` to the reference of the `msg` variable.
-    mov     rsi, msg
-    ;; Set the third argument of `sys_write` to the length of the `msg` variable's value (13 bytes).
-    mov     rdx, 13
-    ;; Call the `sys_write` system call.
-    syscall
+        ;; Specify the number of the system call (1 is `sys_write`).
+        mov rax, 1
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, 1
+        ;; Set the second argument of `sys_write` to the reference of the `msg` variable.
+        mov rsi, msg
+        ;; Set the third argument of `sys_write` to the length of the `msg` variable's value (13 bytes).
+        mov rdx, 13
+        ;; Call the `sys_write` system call.
+        syscall
 
-    ;; Specify the number of the system call (60 is `sys_exit`).
-    mov    rax, 60
-    ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
-    mov    rdi, 0
-    ;; Call the `sys_exit` system call.
-    syscall
+        ;; Specify the number of the system call (60 is `sys_exit`).
+        mov rax, 60
+        ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
+        mov rdi, 0
+        ;; Call the `sys_exit` system call.
+        syscall

--- a/stack/stack.asm
+++ b/stack/stack.asm
@@ -1,162 +1,162 @@
 ;; Definition of the .data section
 section .data
-	;; Number of the `sys_write` system call
-	SYS_WRITE equ 1
-	;; Number of the `sys_exit` system call
-	SYS_EXIT equ 60
-	;; Number of the standard output file descriptor
-	STD_OUT	equ 1
-	;; Exit code from the program. The 0 status code is a success.
-	EXIT_CODE equ 0
-	;; ASCII code of the new line symbol ('\n')
-	NEW_LINE db 0xa
-	;; Error message that is printed in a case of not enough command-line arguments
-	WRONG_ARGC_MSG	db "Error: expected two command-line arguments", 0xa
-	;; Length of the WRONG_ARGC_MSG message
-	WRONG_ARGC_MSG_LEN equ 42
+        ;; Number of the `sys_write` system call
+        SYS_WRITE equ 1
+        ;; Number of the `sys_exit` system call
+        SYS_EXIT equ 60
+        ;; Number of the standard output file descriptor
+        STD_OUT equ 1
+        ;; Exit code from the program. The 0 status code is a success.
+        EXIT_CODE equ 0
+        ;; ASCII code of the new line symbol ('\n')
+        NEW_LINE db 0xa
+        ;; Error message that is printed in a case of not enough command-line arguments
+        WRONG_ARGC_MSG  db "Error: expected two command-line arguments", 0xa
+        ;; Length of the WRONG_ARGC_MSG message
+        WRONG_ARGC_MSG_LEN equ 42
 
 ;; Definition of the .text section
 section .text
-	;; Reference to the entry point of our program
-	global	_start
+        ;; Reference to the entry point of our program
+        global _start
 
 ;; Entry point
 _start:
-	;; Fetch the number of arguments from the stack and store it in the rcx register.
-	pop rcx
-	;; Check the number of the given command-line arguments.
-	cmp rcx, 3
-	;; If not enough, jump to the error subroutine.
-	jne argcError
+        ;; Fetch the number of arguments from the stack and store it in the rcx register.
+        pop rcx
+        ;; Check the number of the given command-line arguments.
+        cmp rcx, 3
+        ;; If not enough, jump to the error subroutine.
+        jne argcError
 
-	;; Skip the first command-line argument which is usually the program name.
-	add rsp, 8
+        ;; Skip the first command-line argument which is usually the program name.
+        add rsp, 8
 
-	;; Fetch the first command-line argument from the stack and store it in the rsi register.
-	pop rsi
-	;; Convert the first command-line argument to an integer number.
-	call str_to_int
-	;; Store the result in the r10 register.
-	mov r10, rax
+        ;; Fetch the first command-line argument from the stack and store it in the rsi register.
+        pop rsi
+        ;; Convert the first command-line argument to an integer number.
+        call str_to_int
+        ;; Store the result in the r10 register.
+        mov r10, rax
 
-	;; Fetch the second command-line argument from the stack and store it in the rsi register.
-	pop rsi
-	;; Convert the second command-line argument to an integer number.
-	call str_to_int
-	;; Store the result in the r11 register.
-	mov r11, rax
+        ;; Fetch the second command-line argument from the stack and store it in the rsi register.
+        pop rsi
+        ;; Convert the second command-line argument to an integer number.
+        call str_to_int
+        ;; Store the result in the r11 register.
+        mov r11, rax
 
-	;; Calculate the sum of the arguments. The result will be stored in the r10 register.
-	add r10, r11
+        ;; Calculate the sum of the arguments. The result will be stored in the r10 register.
+        add r10, r11
 
-	;; Move the sum value to the rax register.
-	mov rax, r10
-	;; Initialize counter by resetting it to 0. It will store the length of the result string.
-	xor rcx, rcx
-	;; Convert the sum from a number to a string to print the result to the standard output.
-	jmp int_to_str
+        ;; Move the sum value to the rax register.
+        mov rax, r10
+        ;; Initialize counter by resetting it to 0. It will store the length of the result string.
+        xor rcx, rcx
+        ;; Convert the sum from a number to a string to print the result to the standard output.
+        jmp int_to_str
 
 ;; Print the error message if not enough command-line arguments.
 argcError:
-	;; Specify the system call number (1 is `sys_write`).
-	mov rax, SYS_WRITE
-	;; Set the first argument of `sys_write` to 1 (`stdout`).
-	mov rdi, STD_OUT
-	;; Set the second argument of `sys_write` to the reference of the `WRONG_ARGC_MSG` variable.
-	mov rsi, WRONG_ARGC_MSG
-	;; Set the third argument to the length of the `WRONG_ARGC_MSG` variable's value.
-	mov rdx, WRONG_ARGC_MSG_LEN
-	;; Call the `sys_write` system call.
-	syscall
-	;; Go to the exit of the program.
-	jmp exit
+        ;; Specify the system call number (1 is `sys_write`).
+        mov rax, SYS_WRITE
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, STD_OUT
+        ;; Set the second argument of `sys_write` to the reference of the `WRONG_ARGC_MSG` variable.
+        mov rsi, WRONG_ARGC_MSG
+        ;; Set the third argument to the length of the `WRONG_ARGC_MSG` variable's value.
+        mov rdx, WRONG_ARGC_MSG_LEN
+        ;; Call the `sys_write` system call.
+        syscall
+        ;; Go to the exit of the program.
+        jmp exit
 
 ;; Convert the command-line argument to the integer number.
 str_to_int:
-	;; Set the value of the rax register to 0. It will store the result.
-	xor rax, rax
-	;; Base for multiplication
-	mov rcx,  10
+        ;; Set the value of the rax register to 0. It will store the result.
+        xor rax, rax
+        ;; Base for multiplication
+        mov rcx, 10
 __repeat:
-	;; Compare the first element in the given string with the `NUL` terminator (end of the string).
-	cmp [rsi], byte 0
-	;; If we reached the end of the string, return from the procedure. The result is stored in the rax register.
-	je __return
-	;; Move the current character from the command-line argument to the bl register.
-	mov bl, [rsi]
-	;; Subtract the value 48 from the ASCII code of the current character.
-	;; This will give us the numeric value of the character.
-	sub bl, 48
-	;; Multiple our result number by 10 to get the place for the next digit.
-	mul rcx
-	;; Add the next digit to our result number.
-	add rax, rbx
-	;; Move to the next character in the command-line argument string.
-	inc rsi
-	;; Repeat until we reach the end of the string.
-	jmp __repeat
+        ;; Compare the first element in the given string with the `NUL` terminator (end of the string).
+        cmp [rsi], byte 0
+        ;; If we reached the end of the string, return from the procedure. The result is stored in the rax register.
+        je __return
+        ;; Move the current character from the command-line argument to the bl register.
+        mov bl, [rsi]
+        ;; Subtract the value 48 from the ASCII code of the current character.
+        ;; This will give us the numeric value of the character.
+        sub bl, 48
+        ;; Multiple our result number by 10 to get the place for the next digit.
+        mul rcx
+        ;; Add the next digit to our result number.
+        add rax, rbx
+        ;; Move to the next character in the command-line argument string.
+        inc rsi
+        ;; Repeat until we reach the end of the string.
+        jmp __repeat
 __return:
-	;; Return from the str_to_int procedure.
-	ret
+        ;; Return from the str_to_int procedure.
+        ret
 
 ;; Convert the sum to a string and print it to the standard output.
 int_to_str:
-	;; High part of the dividend. The low part is in the rax register.
-	mov rdx, 0
-	;; Set the divisor to 10.
-	mov rbx, 10
+        ;; High part of the dividend. The low part is in the rax register.
+        mov rdx, 0
+        ;; Set the divisor to 10.
+        mov rbx, 10
         ;; Divide the sum stored in `rax. The resulting quotient will be stored in `rax`,
-	;; and the remainder will be stored in the `rdx` register.
+        ;; and the remainder will be stored in the `rdx` register.
         div rbx
-	;; Add 48 to the remainder to get a string ASCII representation of the number value.
-	add rdx, 48
-	;; Store the remainder on the stack.
-	push rdx
-	;; Increase the counter.
-	inc rcx
-	;; Compare the rest of the sum with zero.
-	cmp rax, 0x0
-	;; If it is not zero, continue to convert it to string.
-	jne int_to_str
-	;; Otherwise, print the result.
-	jmp printResult
+        ;; Add 48 to the remainder to get a string ASCII representation of the number value.
+        add rdx, 48
+        ;; Store the remainder on the stack.
+        push rdx
+        ;; Increase the counter.
+        inc rcx
+        ;; Compare the rest of the sum with zero.
+        cmp rax, 0x0
+        ;; If it is not zero, continue to convert it to string.
+        jne int_to_str
+        ;; Otherwise, print the result.
+        jmp printResult
 
 ;; Print the result to the standard output.
 printResult:
-	;; Put the number of string characters to the rax register.
-	mov rax, rcx
-	;; Put the value 8 to the rcx register.
-	mov rcx, 8
-	;; Calculate the number of bytes in the given string by multiplying rax by 8.
-	;; The result will be stored in the rax register.
-	mul rcx
+        ;; Put the number of string characters to the rax register.
+        mov rax, rcx
+        ;; Put the value 8 to the rcx register.
+        mov rcx, 8
+        ;; Calculate the number of bytes in the given string by multiplying rax by 8.
+        ;; The result will be stored in the rax register.
+        mul rcx
 
-	;; Set the third argument to the length of the result string to print.
-	mov rdx, rax
-	;; Specify the system call number (1 is `sys_write`).
-	mov rax, SYS_WRITE
-	;; Set the first argument of `sys_write` to 1 (`stdout`).
-	mov rdi, STD_OUT
-  ;; Set the second argument of `sys_write` to the reference of the result string to print.
-	mov rsi, rsp
-	;; Call the `sys_write` system call.
-	syscall
+        ;; Set the third argument to the length of the result string to print.
+        mov rdx, rax
+        ;; Specify the system call number (1 is `sys_write`).
+        mov rax, SYS_WRITE
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, STD_OUT
+        ;; Set the second argument of `sys_write` to the reference of the result string to print.
+        mov rsi, rsp
+        ;; Call the `sys_write` system call.
+        syscall
 
-	;; Specify the system call number (1 is `sys_write`).
-	mov rax, SYS_WRITE
-	;; Set the first argument of `sys_write` to 1 (`stdout`).
-	mov rdi, STD_OUT
-	;; Set the second argument of `sys_write` to the reference of the `NWE_LINE` variable.
-	mov rsi, NEW_LINE
-	;; Set the third argument to the length of the `NEW_LINE` variable's value (1 byte).
-	mov rdx, 1
-	;; Call the `sys_write` system call.
-	syscall
+        ;; Specify the system call number (1 is `sys_write`).
+        mov rax, SYS_WRITE
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, STD_OUT
+        ;; Set the second argument of `sys_write` to the reference of the `NWE_LINE` variable.
+        mov rsi, NEW_LINE
+        ;; Set the third argument to the length of the `NEW_LINE` variable's value (1 byte).
+        mov rdx, 1
+        ;; Call the `sys_write` system call.
+        syscall
 
 exit:
-	;; Specify the number of the system call (60 is `sys_exit`).
-	mov rax, SYS_EXIT
-	;; Set the first argument of `sys_exit` to 0. The 0 status code is a success.
-	mov rdi, EXIT_CODE
-	;; Call the `sys_exit` system call.
-	syscall
+        ;; Specify the number of the system call (60 is `sys_exit`).
+        mov rax, SYS_EXIT
+        ;; Set the first argument of `sys_exit` to 0. The 0 status code is a success.
+        mov rdi, EXIT_CODE
+        ;; Call the `sys_exit` system call.
+        syscall

--- a/strings/reverse.asm
+++ b/strings/reverse.asm
@@ -19,12 +19,12 @@ section .data
 ;; Definition of the .bss section.
 section .bss
         ;; Output buffer where the reversed string will be stored.
-        OUTPUT  resb 1
+        OUTPUT resb 1
 
 ;; Definition of the .text section.
 section .text
         ;; Reference to the entry point of our program.
-        global  _start
+        global _start
 
 ;; Entry point of the program.
 _start:

--- a/sum/sum.asm
+++ b/sum/sum.asm
@@ -1,53 +1,53 @@
 ;; Definition of the .data section
 section .data
-    ;; The first number
-    num1 dq 0x64
-    ;; The second number
-    num2 dq 0x32
-    ;; The message to print if the sum is correct
-    msg  db "The sum is correct!", 10
+        ;; The first number
+        num1 dq 0x64
+        ;; The second number
+        num2 dq 0x32
+        ;; The message to print if the sum is correct
+        msg db "The sum is correct!", 10
 
 ;; Definition of the .text section
 section .text
-    ;; Reference to the entry point of our program
-    global _start
+        ;; Reference to the entry point of our program
+        global _start
 
 ;; Entry point
 _start:
-    ;; Set the value of num1 to rax
-    mov rax, [num1]
-    ;; Set the value of num2 to rbx
-    mov rbx, [num2]
-    ;; Get the sum of rax and rbx. The result is stored in rax.
-    add rax, rbx
+        ;; Set the value of num1 to rax
+        mov rax, [num1]
+        ;; Set the value of num2 to rbx
+        mov rbx, [num2]
+        ;; Get the sum of rax and rbx. The result is stored in rax.
+        add rax, rbx
 .compare:
-    ;; Compare the rax value with 150
-    cmp rax, 150
-    ;; Go to the .exit label if the rax value is not 150
-    jne .exit
-    ;; Go to the .correctSum label if the rax value is 150
-    jmp .correctSum
+        ;; Compare the rax value with 150
+        cmp rax, 150
+        ;; Go to the .exit label if the rax value is not 150
+        jne .exit
+        ;; Go to the .correctSum label if the rax value is 150
+        jmp .correctSum
 
 ;; Print a message that the sum is correct
 .correctSum:
-    ;; Specify the system call number (1 is `sys_write`).
-    mov rax, 1
-    ;; Set the first argument of `sys_write` to 1 (`stdout`).
-    mov rdi, 1
-    ;; Set the second argument of `sys_write` to the reference of the `msg` variable.        
-    mov rsi, msg
-    ;; Set the third argument to the length of the `msg` variable's value (20 bytes).
-    mov rdx, 20
-    ;; Call the `sys_write` system call.
-    syscall
-    ;; Go to the exit of the program.
-    jmp .exit
+        ;; Specify the system call number (1 is `sys_write`).
+        mov rax, 1
+        ;; Set the first argument of `sys_write` to 1 (`stdout`).
+        mov rdi, 1
+        ;; Set the second argument of `sys_write` to the reference of the `msg` variable.
+        mov rsi, msg
+        ;; Set the third argument to the length of the `msg` variable's value (20 bytes).
+        mov rdx, 20
+        ;; Call the `sys_write` system call.
+        syscall
+        ;; Go to the exit of the program.
+        jmp .exit
 
 ;; Exit procedure
 .exit:
-    ;; Specify the number of the system call (60 is `sys_exit`).
-    mov rax, 60
-    ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
-    mov rdi, 0
-    ;; Call the `sys_exit` system call.
-    syscall
+        ;; Specify the number of the system call (60 is `sys_exit`).
+        mov rax, 60
+        ;; Set the first argument of `sys_exit` to 0. The 0 status code is success.
+        mov rdi, 0
+        ;; Call the `sys_exit` system call.
+        syscall


### PR DESCRIPTION
**Description**

This commit provides unification of indentation in all assembly examples:

1. All tabs removed with spaces
2. Indentation should be 8 spaces everywhere
3. Use only one space between and operator and the first operand

Content itself was not touched/changed. Only indentation.

**Related issues**

#42