### PR TITLE
Define INPUT_LEN and adjust OUTPUT buffer size

### DIFF
--- a/content/asm_4.md
+++ b/content/asm_4.md
@@ -159,11 +159,14 @@ section .data
         EXIT_CODE equ 0
         ;; Length of the string that contains only the new line symbol.
         NEW_LINE_LEN equ 1
+        ;; Length of the INPUT string
+        INPUT_LEN equ 12
 
         ;; ASCII code of the new line symbol ('\n').
         NEW_LINE db 0xa
         ;; Input string that we are going to reverse
         INPUT db "Hello world!"
+        
 ```
 
 Here we can see constants and variables that we will use in our program instead of [magic numbers](https://en.wikipedia.org/wiki/Magic_number_(programming)). Note that we predefine the input string that we will reverse in our program. In the previous chapter, you saw how to handle command-line arguments. As a self-exercise, you can extend this program to take a string and reverse it as a command-line argument.
@@ -174,7 +177,7 @@ Next, we define the `.bss` section for our buffer where we will put the reversed
 ;; Definition of the .bss section.
 section .bss
         ;; Output buffer where the reversed string will be stored.
-        OUTPUT resb 1
+        OUTPUT resb INPUT_LEN
 ```
 
 After we defined the data needed to build our program, we can define the `.text` section:


### PR DESCRIPTION
Added INPUT_LEN constant(no magic numbers) and updated OUTPUT buffer size. This was necessary because defining OUTPUT as
```assembly
OUTPUT resb 1 ;; length of 1 byte
```
causes undefined behavior, and possibly a segfault.