### PR TITLE
asm-2: fix typo in instruction

### DIFF
--- a/content/asm_2.md
+++ b/content/asm_2.md
@@ -188,7 +188,7 @@ After defining variables, we can start using them in our program's code. To use 
 
 ```assembly
 ;; Move the address of the `num1` variable to the al register
-move al, num1
+mov al, num1
 ```
 
 To get the actual value located in the given address, we need to specify the variable name in square brackets:


### PR DESCRIPTION
**Description**

This commit provides a fix for a small typo in `mov` instruction.

Related issue: #72 