### PR TITLE
Fix stack examples for nasm 3

### DIFF
--- a/casm/casm1/casm.asm
+++ b/casm/casm1/casm.asm
@@ -1,7 +1,8 @@
 ;; Definition of the `data` section
 section .data
         ;; String variable with the value `hello world!`
-        msg db "hello, world!"
+        ;; `10` is the ASCII code of the new line symbol.
+        msg db "hello, world!", 10
 
         ;; Reference to the C stdlib functions that we will use
         extern write, exit
@@ -17,8 +18,8 @@ _start:
         mov rdi, 1
         ;; Set the second argument of the `write` function to the reference of the `msg` variable.
         mov rsi, msg
-        ;; Set the third argument to the length of the `msg` variable's value (13 bytes).
-        mov rdx, 13
+        ;; Set the third argument to the length of the `msg` variable's value (14 bytes).
+        mov rdx, 14
         ;; Call the `write` function.
         call write
 

--- a/content/asm_1.md
+++ b/content/asm_1.md
@@ -143,7 +143,7 @@ Let's write our first assembly program based on this code sample:
 ;; Definition of the `data` section
 section .data
         ;; String variable with the value `hello world!`. 
-        ;; `10` is the ASCII code for the line feed character (LF), i.e., '\n'.
+        ;; `10` is the ASCII code of the new line symbol.
         msg db "hello, world!", 10
 
 ;; Definition of the text section

--- a/content/asm_2.md
+++ b/content/asm_2.md
@@ -195,7 +195,7 @@ To get the actual value located in the given address, we need to specify the var
 
 ```assembly
 ;; Move the value of num1 to the al register
-mov al, [num1]
+mov al, [rel num1]
 ```
 
 ### Stack
@@ -433,9 +433,9 @@ section .text
 ;; Entry point
 _start:
         ;; Set the value of num1 to rax
-        mov rax, [num1]
+        mov rax, [rel num1]
         ;; Set the value of num2 to rbx
-        mov rbx, [num2]
+        mov rbx, [rel num2]
         ;; Get the sum of rax and rbx. The result is stored in rax.
         add rax, rbx
 .compare:

--- a/content/asm_3.md
+++ b/content/asm_3.md
@@ -156,9 +156,10 @@ section .data
         ;; ASCII code of the new line symbol ('\n')
         NEW_LINE db 0xa
         ;; Error message that is printed in a case of not enough command-line arguments
-        WRONG_ARGC_MSG  db "Error: expected two command-line arguments", 0xa
+        ;; `10` is the ASCII code of the new line symbol.
+        WRONG_ARGC_MSG  db "Error: expected two command-line arguments", 10
         ;; Length of the WRONG_ARGC_MSG message
-        WRONG_ARGC_MSG_LEN equ 42
+        WRONG_ARGC_MSG_LEN equ 43
 
 ;; Definition of the .text section
 section .text
@@ -223,7 +224,7 @@ str_to_int:
         mov rcx, 10
 __repeat:
         ;; Compare the first element in the given string with the `NUL` terminator (end of the string).
-        cmp [rsi], byte 0
+        cmp byte [rsi], 0
         ;; If we reached the end of the string, return from the procedure. The result is stored in the rax register.
         je __return
         ;; Move the current character from the command-line argument to the bl register.
@@ -436,7 +437,7 @@ str_to_int:
         mov rcx, 10
 __repeat:
         ;; Compare the first element in the given string with the `NUL` terminator (end of the string).
-        cmp [rsi], byte 0
+        cmp byte [rsi], 0
         ;; If we reached the end of the string, return from the procedure. The result is stored in the rax register.
         je __return
         ;; Move the current character from the command-line argument to the bl register.

--- a/content/asm_6.md
+++ b/content/asm_6.md
@@ -392,7 +392,7 @@ _parse_first_float_vector:
         call strtod
         ;; Preserve the pointer to the next floating-point value from the input buffer
         ;; in the rax register.
-        mov rax, [end_buffer_1]
+        mov rax, [rel end_buffer_1]
         ;; Check whether it is the end of the input string.
         cmp rax, rdi
         ;; Proceed with the second vector if we reached the end of the first vector.

--- a/content/asm_7.md
+++ b/content/asm_7.md
@@ -18,7 +18,8 @@ Let's go back to the [`hello world`](./asm_1.md) example from the very first cha
 ;; Definition of the `data` section
 section .data
         ;; String variable with the value `hello world!`
-        msg db "hello, world!"
+        ;; `10` is the ASCII code of the new line symbol.
+        msg db "hello, world!", 10
 
 ;; Definition of the text section
 section .text
@@ -34,7 +35,7 @@ _start:
         ;; Set the second argument of `sys_write` to the reference of the `msg` variable.
         mov rsi, msg
         ;; Set the third argument of `sys_write` to the length of the `msg` variable's value (13 bytes).
-        mov rdx, 13
+        mov rdx, 14
         ;; Call the `sys_write` system call.
         syscall
 
@@ -62,7 +63,8 @@ Let's take a look at the implementation:
 ;; Definition of the `data` section
 section .data
         ;; String variable with the value `hello world!`
-        msg db "hello, world!"
+        ;; `10` is the ASCII code of the new line symbol.
+        msg db "hello, world!", 10
 
         ;; Reference to the C stdlib functions that we will use
         extern write, exit
@@ -78,8 +80,8 @@ _start:
         mov rdi, 1
         ;; Set the second argument of the `write` function to the reference of the `msg` variable.
         mov rsi, msg
-        ;; Set the third argument to the length of the `msg` variable's value (13 bytes).
-        mov rdx, 13
+        ;; Set the third argument to the length of the `msg` variable's value (14 bytes).
+        mov rdx, 14
         ;; Call the `write` function.
         call write
 

--- a/float/dot_product.asm
+++ b/float/dot_product.asm
@@ -120,7 +120,7 @@ _parse_first_float_vector:
 
         ;; Preserve the pointer to the next floating-point value from the input buffer
         ;; in the rax register.
-        mov rax, [end_buffer_1]
+        mov rax, [rel end_buffer_1]
         ;; Check whether it is the end of the input string.
         cmp rax, rdi
         ;; Proceed with the second vector if we reached the end of the first vector.
@@ -197,7 +197,7 @@ _parse_second_float_vector:
 
         ;; Preserve the pointer to the next floating-point value from the input buffer
         ;; in the rax register.
-        mov rax, [end_buffer_2]
+        mov rax, [rel end_buffer_2]
         ;; Check whether it is the end of the input string.
         cmp rax, rdi
         ;; Calculate the dot product after we have both vectors.

--- a/hello/hello.asm
+++ b/hello/hello.asm
@@ -1,7 +1,7 @@
 ;; Definition of the `data` section
 section .data
         ;; String variable with the value `hello world!`. 
-        ;; `10` is the ASCII code for the line feed character (LF), i.e., '\n'.
+        ;; `10` is the ASCII code of the new line symbol.
         msg db "hello, world!", 10
 
 ;; Definition of the text section

--- a/stack/stack.asm
+++ b/stack/stack.asm
@@ -11,9 +11,10 @@ section .data
         ;; ASCII code of the new line symbol ('\n')
         NEW_LINE db 0xa
         ;; Error message that is printed in a case of not enough command-line arguments
-        WRONG_ARGC_MSG  db "Error: expected two command-line arguments", 0xa
+        ;; `10` is the ASCII code of the new line symbol.
+        WRONG_ARGC_MSG  db "Error: expected two command-line arguments", 10
         ;; Length of the WRONG_ARGC_MSG message
-        WRONG_ARGC_MSG_LEN equ 42
+        WRONG_ARGC_MSG_LEN equ 43
 
 ;; Definition of the .text section
 section .text
@@ -79,7 +80,7 @@ str_to_int:
         mov rcx, 10
 __repeat:
         ;; Compare the first element in the given string with the `NUL` terminator (end of the string).
-        cmp [rsi], byte 0
+        cmp byte [rsi], 0
         ;; If we reached the end of the string, return from the procedure. The result is stored in the rax register.
         je __return
         ;; Move the current character from the command-line argument to the bl register.

--- a/sum/sum.asm
+++ b/sum/sum.asm
@@ -15,9 +15,9 @@ section .text
 ;; Entry point
 _start:
         ;; Set the value of num1 to rax
-        mov rax, [num1]
+        mov rax, [rel num1]
         ;; Set the value of num2 to rbx
-        mov rbx, [num2]
+        mov rbx, [rel num2]
         ;; Get the sum of rax and rbx. The result is stored in rax.
         add rax, rbx
 .compare:


### PR DESCRIPTION
**Description**

This PR provides the two following fixes:

1. Fix the stack example for nasm version 3.
2. Add new lines everywhere, where we print lines to stdout.